### PR TITLE
fix settings override

### DIFF
--- a/src/frontMatter.ts
+++ b/src/frontMatter.ts
@@ -107,7 +107,7 @@ export const getFrontMatterSettingsOrAlternative = (
     const autoEntry = parseFrontMatterEntry(frontmatter, 'number-headings-auto') ?? parseFrontMatterEntry(frontmatter, 'header-numbering-auto')
     const auto = isValidFlag(autoEntry) ? autoEntry : alternativeSettings.auto
 
-    return { ...DEFAULT_SETTINGS, skipTopLevel, maxLevel, styleLevel1, styleLevelOther, auto }
+    return { ...alternativeSettings, skipTopLevel, maxLevel, styleLevel1, styleLevelOther, auto }
   } else {
     return alternativeSettings
   }


### PR DESCRIPTION
Here need to override `alternativeSettings`, not `DEFAULT_SETTINGS`

https://github.com/onlyafly/number-headings-obsidian/blob/257a9d8e7d66255a56322ac1782f35e6f270c67e/src/frontMatter.ts#L110

fix #19 
