### PR TITLE
Bugfix issue#29

### DIFF
--- a/main.js
+++ b/main.js
@@ -420,7 +420,7 @@ const updateHeadingNumbering = (viewInfo, settings) => {
         return;
     const headings = (_a = viewInfo.data.headings) !== null && _a !== void 0 ? _a : [];
     const editor = viewInfo.editor;
-    const numberingStack = [zerothNumberingTokenInStyle(settings.styleLevel1)];
+    const numberingStack = [];
     //using previousLevel to record the latest **generated** heading level, it is accompanied with the numberingStack's push operation
     let previousLevel = 0; //previousLevel is 0 means the numberingStack is reset
     const changes = [];
@@ -465,10 +465,15 @@ const updateHeadingNumbering = (viewInfo, settings) => {
             }
         }
         else if (level > previousLevel) {
-          if (previousLevel == 0)
+          if (previousLevel === 0)
           {
             // in case the numberingStack is empty(reset)
-            for (let i = settings.firstLevel; i <= level; i++) {
+            if (settings.firstLevel === 1){
+              numberingStack.push(firstNumberingTokenInStyle(settings.styleLevel1));
+            }else{
+              numberingStack.push(firstNumberingTokenInStyle(settings.styleLevelOther));
+            }
+            for (let i = settings.firstLevel; i < level; i++) {
                 numberingStack.push(firstNumberingTokenInStyle(settings.styleLevelOther));
             }
           }else{

--- a/main.js
+++ b/main.js
@@ -422,7 +422,7 @@ const updateHeadingNumbering = (viewInfo, settings) => {
     const editor = viewInfo.editor;
     const numberingStack = [zerothNumberingTokenInStyle(settings.styleLevel1)];
     //using previousLevel to record the latest **generated** heading level, it is accompanied with the numberingStack's push operation
-    let previousLevel = 0;
+    let previousLevel = 0; //previousLevel is 0 means the numberingStack is reset
     const changes = [];
     for (const heading of headings) {
         // Update the numbering stack based on the level and previous level
@@ -431,7 +431,6 @@ const updateHeadingNumbering = (viewInfo, settings) => {
         if (settings.firstLevel > level) {
             //(re)init the empty numberingStack, so that the numbering will be reset.
             numberingStack.splice(0);
-            numberingStack.push(zerothNumberingTokenInStyle(settings.styleLevel1));
             previousLevel = 0;
             continue;
         }
@@ -466,23 +465,18 @@ const updateHeadingNumbering = (viewInfo, settings) => {
             }
         }
         else if (level > previousLevel) {
-          /*
-          todo: if Math.max() is available, the following code block can be replaced by:
-          for (let i = Math.max(settings.firstLevel,previousLevel); i < level; i++) {
-              numberingStack.push(firstNumberingTokenInStyle(settings.styleLevelOther));
-          }
-          */
           if (previousLevel == 0)
           {
-            for (let i = settings.firstLevel; i < level; i++) {
+            // in case the numberingStack is empty(reset)
+            for (let i = settings.firstLevel; i <= level; i++) {
                 numberingStack.push(firstNumberingTokenInStyle(settings.styleLevelOther));
             }
           }else{
+            // in case the numberingStack is not empty
             for (let i = previousLevel; i < level; i++) {
                 numberingStack.push(firstNumberingTokenInStyle(settings.styleLevelOther));
             }
           }
-
         }
         // Set the previous level to this level for the next iteration
         previousLevel = level;
@@ -490,7 +484,7 @@ const updateHeadingNumbering = (viewInfo, settings) => {
             //if the TopLevel is skipped, we number it but do not put the number in the title.
             continue;
         }
-        
+
         // Find the range to replace, and then do it
         const prefixRange = getHeadingPrefixRange(editor, heading);
         if (prefixRange === undefined)

--- a/main.js
+++ b/main.js
@@ -435,15 +435,22 @@ const updateHeadingNumbering = (viewInfo, settings) => {
         // Handle skipped & ignored levels
         if (settings.firstLevel > level) {
             // Leave these headings as they are (this allows people to have numbers at the start of ignored headings)
+            numberingStack.splice(0);
+            numberingStack.push(zerothNumberingTokenInStyle(settings.styleLevel1));
+            if (settings.firstLevel > 1) {
+                previousLevel = settings.firstLevel;
+            }
+            else if (settings.skipTopLevel) {
+                previousLevel = 2;
+            }
             continue;
         }
-        else if ((settings.skipTopLevel && level === 1) || (level > settings.maxLevel)) {
+        else if (level > settings.maxLevel) {
             // Remove any heading numbers in these two cases:
-            // 1. this is a top level and we are skipping top level headings
             // 2. this level is higher than the max level setting
             /* This would allow skipped headings to be stripped of their numbering, but this makes it difficult to truly skip a heading
             const prefixRange = getHeadingPrefixRange(editor, heading)
-      
+
             if (prefixRange) {
               const headingHashString = makeHeadingHashString(editor, heading)
               if (headingHashString === undefined) continue
@@ -652,27 +659,27 @@ class NumberHeadingsPluginSettingTab extends obsidian.PluginSettingTab {
         });
         const ul3 = li4.createEl('ul', {});
         ul3.createEl('li', {
-            text: `      
+            text: `
       For example, '1.1' means both top level and other headings will be numbered starting from '1'.
     `
         });
         ul3.createEl('li', {
-            text: `      
+            text: `
       For example, 'A.1' means top level headings will be numbered starting from 'A'.
     `
         });
         ul3.createEl('li', {
-            text: `      
+            text: `
       For example, '_.A.1' means top level headings will NOT be numbered, but the next levels will be numbered with letters and numbers.
     `
         });
         ul3.createEl('li', {
-            text: `      
+            text: `
       For example, '1.1:' means headings will look like '## 2.4: Example Heading'
     `
         });
         ul3.createEl('li', {
-            text: `      
+            text: `
       For example, 'A.1-' means headings will look like '## B.5- Example Heading'
     `
         });
@@ -784,7 +791,7 @@ class NumberHeadingsPlugin extends obsidian.Plugin {
                             saveSettingsToFrontMatter(viewInfo.data, viewInfo.editor, tweakedSettings);
                         };
                         const config = {
-                            message: `Successfully updated all heading numbers in the document, using the settings below. 
+                            message: `Successfully updated all heading numbers in the document, using the settings below.
               See settings panel to change how headings are numbered, or use front matter
               (see settings panel).`,
                             preformattedMessage: `  Skip top heading level: ${settings.skipTopLevel}

--- a/main.js
+++ b/main.js
@@ -425,9 +425,6 @@ const updateHeadingNumbering = (viewInfo, settings) => {
     if (settings.firstLevel > 1) {
         previousLevel = settings.firstLevel;
     }
-    else if (settings.skipTopLevel) {
-        previousLevel = 2;
-    }
     const changes = [];
     for (const heading of headings) {
         // Update the numbering stack based on the level and previous level
@@ -440,9 +437,11 @@ const updateHeadingNumbering = (viewInfo, settings) => {
             if (settings.firstLevel > 1) {
                 previousLevel = settings.firstLevel;
             }
+            /*
             else if (settings.skipTopLevel) {
                 previousLevel = 2;
             }
+            */
             continue;
         }
         else if (level > settings.maxLevel) {
@@ -482,8 +481,8 @@ const updateHeadingNumbering = (viewInfo, settings) => {
         }
         // Set the previous level to this level for the next iteration
         previousLevel = level;
-        if (level > settings.maxLevel) {
-            // If we are above the max level, just don't number it
+        if (settings.skipTopLevel && level === 1) {
+            //if the TopLevel is skipped, we number it but do not put the number in the title.
             continue;
         }
         // Find the range to replace, and then do it


### PR DESCRIPTION
Hi, 
this pull request tries to solve issue#29 and improves/modifies the numbering policy as shown as the following examples (please notice the changes in the yaml)

without numbering:
```md
# h1
## h1-2
### h1-2-1
## h1-3
### h1-3-1
### h1-3-2

# h2
## h2-1
### h2-1-1
### h2-1-2
## h2-2
```

Example 1:
```md
---
number headings: auto, first-level 1, max 6, _.1.1.
---
# h1
## 1.1. h1-2
### 1.1.1. h1-2-1
## 1.2. h1-3
### 1.2.1. h1-3-1
### 1.2.2. h1-3-2

# h2
## 2.1. h2-1
### 2.1.1. h2-1-1
### 2.1.2. h2-1-2
## 2.2. h2-2
```
Example 2：
```md
---
number headings: auto, first-level 1, max 6, 1.1.
---
# 1. h1
## 1.1. h1-2
### 1.1.1. h1-2-1
## 1.2. h1-3
### 1.2.1. h1-3-1
### 1.2.2. h1-3-2

# 2. h2
## 2.1. h2-1
### 2.1.1. h2-1-1
### 2.1.2. h2-1-2
## 2.2. h2-2
```
Example 3:
```md
---
number headings: auto, first-level 3, max 6, _.1.1.
---
# h1
## h1-2
### 1. h1-2-1
## h1-3
### 1. h1-3-1
### 2. h1-3-2

# h2
## h2-1
### 1. h2-1-1
### 2. h2-1-2
## h2-2
```
Example 4:
```md
---
number headings: auto, first-level 3, max 6, _.1.1.
aliases:   
---
# h1
## h1-2
### 1. h1-2-1
## h1-3
### 1. h1-3-1
### 2. h1-3-2

# h2
## h2-1
### 1. h2-1-1
### 2. h2-1-2
## h2-2
```
(Example 3 and Example 4 look the same)
